### PR TITLE
Add -service-name as a parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,9 @@ options:
     	where lrt should listen (default "localhost:3000")
   -service string
     	where your service listens (if it does not listen on $PORT)
+  -service-name string
+    	If you provider a service name, it will be used on the temp file.
+    	It makes easy to find the correct process if you are running more than one lrt service.
 
 lrt listens on localhost:3000 and boots your service with a PORT environment variable set.
 Your service should start an HTTP server on the provided port. For more details see:

--- a/go.mod
+++ b/go.mod
@@ -6,4 +6,5 @@ require (
 	github.com/fsnotify/fsnotify v1.4.9
 	github.com/mattn/go-shellwords v1.0.3
 	github.com/sirkon/goproxy v1.4.8
+	golang.org/x/sys v0.0.0-20220731174439-a90be440212d // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -26,6 +26,8 @@ golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20191005200804-aed5e4c7ecf9 h1:L2auWcuQIvxz9xSEqzESnV/QN/gNRXNApHi3fYwl2w0=
 golang.org/x/sys v0.0.0-20191005200804-aed5e4c7ecf9/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20220731174439-a90be440212d h1:Sv5ogFZatcgIMMtBSTTAgMYsicp25MXBubjXNDKwm80=
+golang.org/x/sys v0.0.0-20220731174439-a90be440212d/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/tools v0.0.0-20190425163242-31fd60d6bfdc/go.mod h1:RgjU9mgBXZiqYHBnxXauZ1Gv1EHHAz9KjViQ78xBX0Q=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/main.go
+++ b/main.go
@@ -44,6 +44,7 @@ import (
 var (
 	listenFlag      = flag.String("listen", "localhost:3000", "where lrt should listen")
 	serviceFlag     = flag.String("service", "", "where your service listens (if it does not listen on $PORT)")
+	serviceNameFlag = flag.String("service-name", "", "If you provider a service name, it will be used on the temp file.\nIt makes easy to find the correct process if you are running more than one lrt service.")
 	buildArgsFlag   = flag.String("build-args", "", "extra flags to pass to go build")
 	cmdArgsFlag     = flag.String("cmd-args", "", "extra flags to pass to the service executable")
 	healthCheckFlag = flag.String("health-check", "/", "the path lrt pings to check your service has started")
@@ -558,7 +559,12 @@ https://github.com/superhuman/lrt
 		panic(err) // can only happen if shellwords.ParseBacktick is true, and it isn't
 	}
 
-	tmpFile, err = ioutil.TempFile("", "lrt-service")
+	pattern := "lrt-service"
+	if *serviceNameFlag != "" {
+		pattern += "-" + *serviceNameFlag + "-"
+	}
+
+	tmpFile, err = ioutil.TempFile("", pattern)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "lrt: "+err.Error())
 		os.Exit(1)

--- a/main_test.go
+++ b/main_test.go
@@ -246,7 +246,7 @@ func TestLrt_ServiceArg(t *testing.T) {
 
 	anotherURL := generateServiceURL(baseListenURL)
 
-	listenURL, stop := startLrtForTests(t, "-cmd-args", "-override-port "+anotherURL.Port(), "-service", anotherURL.Host)
+	listenURL, stop := startLrtForTests(t, "-cmd-args", "-override-port "+anotherURL.Port(), "-service", anotherURL.Host, "-service-name", "TestLrt")
 	defer stop()
 
 	response := getStringResponse(t, listenURL)


### PR DESCRIPTION
Reasoning: 
When you are running more than one lrt in the same machine for different services is really hard to tell which one is which. 
The proposed parameter is to add an optional `service-name` parameter that would be appended to the temp name. 

Before: 
Command `./lrt . `
![image](https://user-images.githubusercontent.com/1175744/182707457-e832a655-5ce8-4f35-8c73-2f32b51a93a3.png)

After:
Command `./lrt -service-name backend . `
![image](https://user-images.githubusercontent.com/1175744/182707365-3f11127f-fb8f-467a-a319-f2edece46917.png)

Backwards compatibility:
Since this is an optional parameter, no changes would happen to the previous version. So, it's backwards compatible

